### PR TITLE
Test 3rd Party Buildpack in Multi-Buildpack Solution

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -4,4 +4,5 @@ applications:
   random-route: true
   buildpacks:
     - python_buildpack
+    - https://github.com/alexandreroman/markdown-buildpack.git
   memory: 128M

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,6 +3,6 @@ applications:
 - name: 10x-dux-app
   random-route: true
   buildpacks:
-    - python_buildpack
     - https://github.com/alexandreroman/markdown-buildpack.git
+    - python_buildpack
   memory: 128M


### PR DESCRIPTION
This is a strawman to see if this approach even works for an ongoing discussion of different buildpack deployment solutions in conjunction with lead-in work on flexion/vuls-cloudfoundry-buildpack#1. This will likely not be merged, but closed.

Chosen for this experiment was a simple buildpack that will, in theory, render HTML from existing Markdown files in repo. This is just evaluate if the buildpack loaded; we are not concerned with actual HTML files and their use in app deployment.