### PR TITLE
Add parameterized env var.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: ${{ secrets.CG_ORG }}
           cf_space: ${{ secrets.CG_SPACE }}
-          cf_command: push -f manifest.yml 10x-dux-app-dev1
+          cf_command: push -f manifest.yml 10x-dux-app-dev1 --var vuls_http_server=${{ secrets.VULS_HTTP_SERVER }}
       - name: Deploy to cloud.gov (UAT)
         if: github.ref == 'refs/heads/master'
         uses: flexion/cg-cli-tools@fix-custom-cf-command
@@ -56,4 +56,4 @@ jobs:
           cf_password: ${{ secrets.CG_PASSWORD }}
           cf_org: ${{ secrets.CG_ORG }}
           cf_space: ${{ secrets.CG_SPACE }}
-          cf_command: push -f manifest.yml 10x-dux-app-uat1
+          cf_command: push -f manifest.yml 10x-dux-app-uat1 --var vuls_http_server=${{ secrets.VULS_HTTP_SERVER }}

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,3 +6,5 @@ applications:
     - https://github.com/flexion/vuls-cloudfoundry-buildpack.git#develop
     - python_buildpack
   memory: 128M
+  env:
+    VULS_HTTP_SERVER: ((vuls_http_server))

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,5 +3,6 @@ applications:
 - name: 10x-dux-app
   random-route: true
   buildpacks:
+    - https://github.com/flexion/vuls-cloudfoundry-buildpack.git#develop
     - python_buildpack
   memory: 128M


### PR DESCRIPTION
Per ongoing work in flexion/vuls-cloudfoundry-buildpack#2, we do not
want to directly store IP address or hostname of proof-of-concept server
for vuls in our test lab, or anywhere directly in the buildpack at this time.

This parameterized vuls_http_server var is passed in at `cf push` time to
ensure during first build or successive deployments with `cf set-env` and
`cf restage` we can beta-test the plugin without storing sensitive data.